### PR TITLE
fix: Replace fs.read with fs.read_as_string in the custom transformers

### DIFF
--- a/add-custom-files-directories-in-custom-locations/customhelmchartgen.star
+++ b/add-custom-files-directories-in-custom-locations/customhelmchartgen.star
@@ -49,7 +49,7 @@ def transform(new_artifacts, old_artifacts):
 
 # Extracts service name from pom file
 def getServiceName(filePath):
-    data = fs.read(filePath)
+    data = fs.read_as_string(filePath)
     lines = data.splitlines()
     for l in lines:
         if re.search("^[\t]<artifactId", l):

--- a/add-custom-kubernetes-annotation/ingress-annotator.star
+++ b/add-custom-kubernetes-annotation/ingress-annotator.star
@@ -35,7 +35,7 @@ def transform(new_artifacts, old_artifacts):
                             'templateConfig': tplPathData})
         for f in fileList:
             filePath = fs.path_join(yamlsPath, f)
-            s = fs.read(filePath)
+            s = fs.read_as_string(filePath)
             yamlData = yaml.loads(s)
             if yamlData['kind'] != 'Ingress':
                 continue

--- a/custom-m2kcollect-yaml-file-to-csv-file/collectadapter.star
+++ b/custom-m2kcollect-yaml-file-to-csv-file/collectadapter.star
@@ -93,7 +93,7 @@ def transform(new_artifacts, old_artifacts):
     for v in new_artifacts:
         cfAppsFilesPaths = v["paths"]["CfAppsFilesPaths"]
         for cfAppsFilePath in cfAppsFilesPaths:
-            s = fs.read(cfAppsFilePath)
+            s = fs.read_as_string(cfAppsFilePath)
             yamlData = yaml.loads(s)
             app = {}
             for applications in yamlData["spec"]["applications"]:


### PR DESCRIPTION
In the PR https://github.com/konveyor/move2kube/pull/987, fs.read() got replaced by fs.read_as_string().