### PR TITLE
fix: Rename the new-category to ports and move the url path question from the ports category to network category

### DIFF
--- a/enable-disable-qa-categories/custom-qa-mapping/qamappings.yaml
+++ b/enable-disable-qa-categories/custom-qa-mapping/qamappings.yaml
@@ -50,12 +50,12 @@ spec:
       questions:
         - move2kube.services.*.*.servicetype
         - move2kube.target.*.ingress.ingressclassname
+        - move2kube.services.*.*.urlpath
         - move2kube.target.*.ingress.host
         - move2kube.target.*.ingress.tls
-    - name: new-category
+    - name: ports
       enabled: true
       questions:
-        - move2kube.services.*.*.urlpath
         - move2kube.services.*.ports
         - move2kube.services.*.port
     - name: git


### PR DESCRIPTION
Related - https://github.com/konveyor/move2kube/issues/1151

Signed-off-by: Akash Nayak <akash19nayak@gmail.com>